### PR TITLE
feat: v1.1 Community & v1.2 Input Expansion

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -10,6 +10,7 @@ import Discover from "./pages/Discover";
 import Library from "./pages/Library";
 import ContentDetail from "./pages/ContentDetail";
 import Profile from "./pages/Profile";
+import Feed from "./pages/Feed";
 import Layout from "./components/Layout";
 
 function Router() {
@@ -19,6 +20,7 @@ function Router() {
         <Route path="/" component={Home} />
         <Route path="/create" component={Create} />
         <Route path="/discover" component={Discover} />
+        <Route path="/feed" component={Feed} />
         <Route path="/library" component={Library} />
         <Route path="/content/:id" component={ContentDetail} />
         <Route path="/profile/:id" component={Profile} />

--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -11,11 +11,12 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { trpc } from "@/lib/trpc";
 import { Link, useLocation } from "wouter";
-import { Sparkles, Compass, BookOpen, LogOut, User, Plus } from "lucide-react";
+import { Sparkles, Compass, BookOpen, LogOut, User, Plus, Rss } from "lucide-react";
 import { toast } from "sonner";
 
 const NAV_LINKS = [
   { href: "/discover", label: "Discover", icon: Compass },
+  { href: "/feed", label: "Feed", icon: Rss },
   { href: "/library", label: "My Library", icon: BookOpen },
 ];
 

--- a/client/src/pages/ContentDetail.tsx
+++ b/client/src/pages/ContentDetail.tsx
@@ -8,7 +8,9 @@ import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Link, useParams } from "wouter";
 import { useState } from "react";
 import { toast } from "sonner";
-import { Heart, Bookmark, MessageCircle, Eye, ArrowLeft, Loader2, Send, Trash2, Globe, Lock } from "lucide-react";
+import { Heart, Bookmark, MessageCircle, Eye, ArrowLeft, Loader2, Send, Trash2, Globe, Lock, Shuffle, GitFork } from "lucide-react";
+import { useLocation } from "wouter";
+import ContentCard from "@/components/ContentCard";
 
 // ─── Format Viewers ────────────────────────────────────────────────────────────
 
@@ -226,15 +228,26 @@ function ContentViewer({ format, outputData }: { format: string; outputData: str
 
 // ─── Main Page ────────────────────────────────────────────────────────────────
 
+const REMIX_FORMATS = [
+  { value: "novel", label: "📖 Novel" },
+  { value: "manga", label: "🎌 Manga" },
+  { value: "flashcard", label: "🃏 Flashcard" },
+  { value: "video_script", label: "🎬 Video Script" },
+  { value: "poem", label: "✍️ Poem" },
+] as const;
+
 export default function ContentDetail() {
   const params = useParams<{ id: string }>();
   const id = parseInt(params.id ?? "0");
   const { user, isAuthenticated } = useAuth();
   const utils = trpc.useUtils();
+  const [, navigate] = useLocation();
   const [commentText, setCommentText] = useState("");
+  const [showRemixMenu, setShowRemixMenu] = useState(false);
 
   const { data, isLoading, error } = trpc.content.getById.useQuery({ id }, { enabled: !!id });
   const { data: comments, isLoading: commentsLoading } = trpc.content.getComments.useQuery({ contentId: id }, { enabled: !!id });
+  const { data: remixes } = trpc.content.getRemixes.useQuery({ contentId: id }, { enabled: !!id });
 
   const likeMutation = trpc.content.toggleLike.useMutation({
     onSuccess: (res) => {
@@ -248,6 +261,14 @@ export default function ContentDetail() {
       utils.content.getById.invalidate({ id });
       toast.success(res.bookmarked ? "Bookmarked!" : "Removed from bookmarks");
     },
+  });
+
+  const remixMutation = trpc.content.remix.useMutation({
+    onSuccess: (res) => {
+      toast.success("Remix created!");
+      navigate(`/content/${res.contentId}`);
+    },
+    onError: () => toast.error("Remix failed"),
   });
 
   const commentMutation = trpc.content.addComment.useMutation({
@@ -364,14 +385,80 @@ export default function ContentDetail() {
               <Bookmark className={`w-4 h-4 ${bookmarked ? "fill-current" : ""}`} />
               Save
             </Button>
+            {/* Remix button */}
+            <div className="relative">
+              <Button
+                variant="outline"
+                size="sm"
+                className="gap-2 border-border/60 text-muted-foreground hover:text-foreground hover:border-primary/40"
+                onClick={() => {
+                  if (!isAuthenticated) { window.location.href = getLoginUrl(); return; }
+                  setShowRemixMenu(!showRemixMenu);
+                }}
+                disabled={remixMutation.isPending}
+              >
+                {remixMutation.isPending ? (
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                ) : (
+                  <Shuffle className="w-4 h-4" />
+                )}
+                Remix
+                {(content as any).remixCount > 0 && <span className="text-xs opacity-70">{(content as any).remixCount}</span>}
+              </Button>
+              {showRemixMenu && (
+                <div className="absolute right-0 top-full mt-2 z-50 bg-card border border-border/60 rounded-xl shadow-xl p-2 min-w-44">
+                  <p className="text-xs text-muted-foreground px-3 py-1.5 font-medium">Convert to:</p>
+                  {REMIX_FORMATS
+                    .filter((f) => f.value !== content.outputFormat)
+                    .map((f) => (
+                      <button
+                        key={f.value}
+                        className="w-full text-left px-3 py-2 rounded-lg text-sm hover:bg-muted/50 transition-colors"
+                        onClick={() => {
+                          setShowRemixMenu(false);
+                          remixMutation.mutate({ contentId: id, targetFormat: f.value, isPublic: true });
+                        }}
+                      >
+                        {f.label}
+                      </button>
+                    ))}
+                </div>
+              )}
+            </div>
           </div>
         </div>
       </div>
+
+      {/* Remix source link */}
+      {(content as any).parentContentId && (
+        <div className="mb-6 flex items-center gap-2 text-sm text-muted-foreground">
+          <GitFork className="w-4 h-4" />
+          <span>Remixed from</span>
+          <Link href={`/content/${(content as any).parentContentId}`}>
+            <span className="text-primary hover:underline cursor-pointer">original content</span>
+          </Link>
+        </div>
+      )}
 
       {/* Content viewer */}
       <div className="rounded-2xl border border-border/60 bg-card p-8 mb-10">
         <ContentViewer format={content.outputFormat} outputData={content.outputData} />
       </div>
+
+      {/* Remixes */}
+      {remixes && remixes.length > 0 && (
+        <div className="mb-10">
+          <h2 className="text-xl font-bold mb-6 flex items-center gap-2">
+            <Shuffle className="w-5 h-5" />
+            Remixes ({remixes.length})
+          </h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {remixes.map((item) => (
+              <ContentCard key={item.content.id} content={item.content} author={item.author} />
+            ))}
+          </div>
+        </div>
+      )}
 
       {/* Source text (collapsed) */}
       <details className="mb-10 rounded-xl border border-border/60 bg-card">

--- a/client/src/pages/Create.tsx
+++ b/client/src/pages/Create.tsx
@@ -7,10 +7,10 @@ import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { Badge } from "@/components/ui/badge";
 import { trpc } from "@/lib/trpc";
-import { useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { useLocation } from "wouter";
 import { toast } from "sonner";
-import { Sparkles, Loader2, X, Lock, Globe } from "lucide-react";
+import { Sparkles, Loader2, X, Lock, Globe, Type, Image, FileText, Link2, Upload, Check } from "lucide-react";
 
 const OUTPUT_FORMATS = [
   { value: "novel", label: "📖 Novel", desc: "Short story format" },
@@ -21,6 +21,15 @@ const OUTPUT_FORMATS = [
 ] as const;
 
 type OutputFormat = (typeof OUTPUT_FORMATS)[number]["value"];
+
+const INPUT_MODES = [
+  { value: "text", label: "Text", icon: Type, desc: "Paste text directly" },
+  { value: "image", label: "Image", icon: Image, desc: "Upload photo of notes" },
+  { value: "pdf", label: "PDF", icon: FileText, desc: "Upload a PDF document" },
+  { value: "url", label: "URL", icon: Link2, desc: "Extract from a webpage" },
+] as const;
+
+type InputMode = (typeof INPUT_MODES)[number]["value"];
 
 export default function Create() {
   const { isAuthenticated } = useAuth();
@@ -34,6 +43,13 @@ export default function Create() {
   const [tagInput, setTagInput] = useState("");
   const [tags, setTags] = useState<string[]>([]);
 
+  // v1.2 input mode state
+  const [inputMode, setInputMode] = useState<InputMode>("text");
+  const [urlInput, setUrlInput] = useState("");
+  const [uploadedFileName, setUploadedFileName] = useState("");
+  const [uploadedFileUrl, setUploadedFileUrl] = useState("");
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
   const generateMutation = trpc.content.generate.useMutation({
     onSuccess: (data) => {
       toast.success("Content generated successfully!");
@@ -42,6 +58,22 @@ export default function Create() {
     onError: (err) => {
       toast.error("Generation failed: " + err.message);
     },
+  });
+
+  const uploadMutation = trpc.content.uploadFile.useMutation({
+    onSuccess: (data) => {
+      setUploadedFileUrl(data.url);
+      toast.success("File uploaded!");
+    },
+    onError: () => toast.error("Upload failed"),
+  });
+
+  const extractMutation = trpc.content.extractText.useMutation({
+    onSuccess: (data) => {
+      setSourceText(data.text);
+      toast.success("Text extracted! Review and edit below.");
+    },
+    onError: (err) => toast.error("Extraction failed: " + err.message),
   });
 
   if (!isAuthenticated) {
@@ -76,6 +108,56 @@ export default function Create() {
     }
   };
 
+  const handleFileSelect = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    const maxSize = 10 * 1024 * 1024; // 10MB
+    if (file.size > maxSize) {
+      toast.error("File too large (max 10MB)");
+      return;
+    }
+
+    const validTypes = inputMode === "image"
+      ? ["image/png", "image/jpeg", "image/webp"]
+      : ["application/pdf"];
+    if (!validTypes.includes(file.type)) {
+      toast.error(`Invalid file type. Expected: ${validTypes.join(", ")}`);
+      return;
+    }
+
+    setUploadedFileName(file.name);
+
+    // Convert to base64
+    const reader = new FileReader();
+    reader.onload = () => {
+      const base64 = (reader.result as string).split(",")[1];
+      uploadMutation.mutate({
+        fileBase64: base64,
+        fileName: file.name,
+        mimeType: file.type as any,
+      });
+    };
+    reader.readAsDataURL(file);
+  }, [inputMode, uploadMutation]);
+
+  const handleExtractText = () => {
+    if (inputMode === "url") {
+      if (!urlInput.trim()) {
+        toast.error("Please enter a URL");
+        return;
+      }
+      extractMutation.mutate({ source: "url", url: urlInput.trim() });
+    } else if (uploadedFileUrl) {
+      extractMutation.mutate({
+        source: inputMode as "image" | "pdf",
+        url: uploadedFileUrl,
+      });
+    } else {
+      toast.error("Please upload a file first");
+    }
+  };
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!title.trim() || !sourceText.trim()) {
@@ -86,6 +168,7 @@ export default function Create() {
   };
 
   const isLoading = generateMutation.isPending;
+  const isExtracting = extractMutation.isPending || uploadMutation.isPending;
 
   return (
     <div className="container py-12 max-w-3xl">
@@ -111,22 +194,181 @@ export default function Create() {
           />
         </div>
 
-        {/* Source text */}
-        <div className="space-y-2">
-          <Label htmlFor="sourceText" className="text-sm font-medium">
-            Content to transform <span className="text-destructive">*</span>
-          </Label>
-          <Textarea
-            id="sourceText"
-            placeholder="Paste your text here — notes, articles, study material, anything you want to transform..."
-            value={sourceText}
-            onChange={(e) => setSourceText(e.target.value)}
-            className="bg-card border-border/60 focus:border-primary/60 min-h-48 resize-none"
-            maxLength={10000}
-            disabled={isLoading}
-          />
-          <p className="text-xs text-muted-foreground text-right">{sourceText.length}/10000</p>
+        {/* Input mode selector */}
+        <div className="space-y-3">
+          <Label className="text-sm font-medium">Input source</Label>
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+            {INPUT_MODES.map((mode) => {
+              const Icon = mode.icon;
+              return (
+                <button
+                  key={mode.value}
+                  type="button"
+                  onClick={() => setInputMode(mode.value)}
+                  disabled={isLoading}
+                  className={`flex flex-col items-center gap-1.5 rounded-xl border p-3 text-center transition-all ${
+                    inputMode === mode.value
+                      ? "border-primary bg-primary/10 text-primary"
+                      : "border-border/60 bg-card text-muted-foreground hover:border-primary/40 hover:text-foreground"
+                  }`}
+                >
+                  <Icon className="w-5 h-5" />
+                  <span className="text-xs font-medium">{mode.label}</span>
+                </button>
+              );
+            })}
+          </div>
         </div>
+
+        {/* Input area - changes based on mode */}
+        {inputMode === "text" ? (
+          <div className="space-y-2">
+            <Label htmlFor="sourceText" className="text-sm font-medium">
+              Content to transform <span className="text-destructive">*</span>
+            </Label>
+            <Textarea
+              id="sourceText"
+              placeholder="Paste your text here — notes, articles, study material, anything you want to transform..."
+              value={sourceText}
+              onChange={(e) => setSourceText(e.target.value)}
+              className="bg-card border-border/60 focus:border-primary/60 min-h-48 resize-none"
+              maxLength={10000}
+              disabled={isLoading}
+            />
+            <p className="text-xs text-muted-foreground text-right">{sourceText.length}/10000</p>
+          </div>
+        ) : inputMode === "url" ? (
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label className="text-sm font-medium">
+                Web page URL <span className="text-destructive">*</span>
+              </Label>
+              <div className="flex gap-2">
+                <Input
+                  placeholder="https://example.com/article"
+                  value={urlInput}
+                  onChange={(e) => setUrlInput(e.target.value)}
+                  className="bg-card border-border/60 focus:border-primary/60"
+                  disabled={isLoading || isExtracting}
+                />
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="gap-2 shrink-0 border-primary/40 text-primary hover:bg-primary/10"
+                  onClick={handleExtractText}
+                  disabled={isLoading || isExtracting || !urlInput.trim()}
+                >
+                  {isExtracting ? (
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                  ) : (
+                    <Link2 className="w-4 h-4" />
+                  )}
+                  Extract
+                </Button>
+              </div>
+            </div>
+            {sourceText && (
+              <div className="space-y-2">
+                <Label className="text-sm font-medium flex items-center gap-2">
+                  <Check className="w-4 h-4 text-green-500" />
+                  Extracted text (review & edit)
+                </Label>
+                <Textarea
+                  value={sourceText}
+                  onChange={(e) => setSourceText(e.target.value)}
+                  className="bg-card border-border/60 focus:border-primary/60 min-h-48 resize-none"
+                  maxLength={10000}
+                  disabled={isLoading}
+                />
+                <p className="text-xs text-muted-foreground text-right">{sourceText.length}/10000</p>
+              </div>
+            )}
+          </div>
+        ) : (
+          /* Image / PDF upload */
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label className="text-sm font-medium">
+                Upload {inputMode === "image" ? "image" : "PDF"} <span className="text-destructive">*</span>
+              </Label>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept={inputMode === "image" ? "image/png,image/jpeg,image/webp" : "application/pdf"}
+                onChange={handleFileSelect}
+                className="hidden"
+              />
+              <div
+                className={`flex flex-col items-center justify-center gap-3 rounded-xl border-2 border-dashed p-8 transition-all cursor-pointer hover:border-primary/40 ${
+                  uploadedFileUrl
+                    ? "border-green-500/40 bg-green-500/5"
+                    : "border-border/60 bg-card"
+                }`}
+                onClick={() => fileInputRef.current?.click()}
+              >
+                {uploadMutation.isPending ? (
+                  <>
+                    <Loader2 className="w-8 h-8 animate-spin text-primary" />
+                    <p className="text-sm text-muted-foreground">Uploading...</p>
+                  </>
+                ) : uploadedFileUrl ? (
+                  <>
+                    <Check className="w-8 h-8 text-green-500" />
+                    <p className="text-sm font-medium">{uploadedFileName}</p>
+                    <p className="text-xs text-muted-foreground">Click to replace</p>
+                  </>
+                ) : (
+                  <>
+                    <Upload className="w-8 h-8 text-muted-foreground" />
+                    <p className="text-sm text-muted-foreground">
+                      {inputMode === "image"
+                        ? "Drop an image here or click to upload (PNG, JPG, WebP)"
+                        : "Drop a PDF here or click to upload"}
+                    </p>
+                    <p className="text-xs text-muted-foreground">Max 10MB</p>
+                  </>
+                )}
+              </div>
+              {uploadedFileUrl && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="w-full gap-2 border-primary/40 text-primary hover:bg-primary/10"
+                  onClick={handleExtractText}
+                  disabled={isExtracting}
+                >
+                  {isExtracting ? (
+                    <>
+                      <Loader2 className="w-4 h-4 animate-spin" />
+                      Extracting text with AI...
+                    </>
+                  ) : (
+                    <>
+                      <Sparkles className="w-4 h-4" />
+                      Extract text from {inputMode === "image" ? "image" : "PDF"}
+                    </>
+                  )}
+                </Button>
+              )}
+            </div>
+            {sourceText && (
+              <div className="space-y-2">
+                <Label className="text-sm font-medium flex items-center gap-2">
+                  <Check className="w-4 h-4 text-green-500" />
+                  Extracted text (review & edit)
+                </Label>
+                <Textarea
+                  value={sourceText}
+                  onChange={(e) => setSourceText(e.target.value)}
+                  className="bg-card border-border/60 focus:border-primary/60 min-h-48 resize-none"
+                  maxLength={10000}
+                  disabled={isLoading}
+                />
+                <p className="text-xs text-muted-foreground text-right">{sourceText.length}/10000</p>
+              </div>
+            )}
+          </div>
+        )}
 
         {/* Output format */}
         <div className="space-y-3">

--- a/client/src/pages/Discover.tsx
+++ b/client/src/pages/Discover.tsx
@@ -4,7 +4,7 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Link } from "wouter";
-import { Search, Heart, MessageCircle, Eye, Loader2 } from "lucide-react";
+import { Search, Loader2, TrendingUp, Clock, Trophy, Tag, X } from "lucide-react";
 import ContentCard from "@/components/ContentCard";
 
 const FORMAT_FILTERS = [
@@ -16,17 +16,37 @@ const FORMAT_FILTERS = [
   { value: "poem", label: "✍️ Poem" },
 ] as const;
 
+const SORT_OPTIONS = [
+  { value: "recent", label: "New", icon: Clock },
+  { value: "trending", label: "Trending", icon: TrendingUp },
+  { value: "top", label: "Top", icon: Trophy },
+] as const;
+
+const PERIOD_OPTIONS = [
+  { value: "week", label: "This Week" },
+  { value: "month", label: "This Month" },
+  { value: "all", label: "All Time" },
+] as const;
+
 export default function Discover() {
   const [keyword, setKeyword] = useState("");
   const [searchInput, setSearchInput] = useState("");
   const [format, setFormat] = useState<string | undefined>(undefined);
+  const [sortBy, setSortBy] = useState<"recent" | "trending" | "top">("recent");
+  const [period, setPeriod] = useState<"week" | "month" | "all">("all");
+  const [selectedTag, setSelectedTag] = useState<string | undefined>(undefined);
 
   const { data, isLoading } = trpc.content.discover.useQuery({
     keyword: keyword || undefined,
     format: format as any,
+    tagName: selectedTag,
+    sortBy,
+    period,
     limit: 24,
     offset: 0,
   });
+
+  const { data: popularTags } = trpc.content.popularTags.useQuery({ limit: 15 });
 
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
@@ -58,6 +78,48 @@ export default function Discover() {
           </Button>
         </form>
 
+        {/* Sort tabs */}
+        <div className="flex items-center gap-4">
+          <div className="flex gap-1 p-1 rounded-lg bg-muted/50 border border-border/40">
+            {SORT_OPTIONS.map((opt) => {
+              const Icon = opt.icon;
+              return (
+                <button
+                  key={opt.value}
+                  onClick={() => setSortBy(opt.value)}
+                  className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium transition-all ${
+                    sortBy === opt.value
+                      ? "bg-background text-foreground shadow-sm"
+                      : "text-muted-foreground hover:text-foreground"
+                  }`}
+                >
+                  <Icon className="w-3.5 h-3.5" />
+                  {opt.label}
+                </button>
+              );
+            })}
+          </div>
+
+          {/* Period filter (only show for trending/top) */}
+          {sortBy !== "recent" && (
+            <div className="flex gap-1">
+              {PERIOD_OPTIONS.map((opt) => (
+                <button
+                  key={opt.value}
+                  onClick={() => setPeriod(opt.value)}
+                  className={`px-3 py-1.5 rounded-md text-xs font-medium transition-all ${
+                    period === opt.value
+                      ? "bg-primary/10 text-primary border border-primary/30"
+                      : "text-muted-foreground hover:text-foreground border border-transparent"
+                  }`}
+                >
+                  {opt.label}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
         {/* Format filters */}
         <div className="flex flex-wrap gap-2">
           {FORMAT_FILTERS.map((f) => (
@@ -74,6 +136,34 @@ export default function Discover() {
             </button>
           ))}
         </div>
+
+        {/* Popular tags */}
+        {popularTags && popularTags.length > 0 && (
+          <div className="flex items-center gap-2 flex-wrap">
+            <Tag className="w-3.5 h-3.5 text-muted-foreground shrink-0" />
+            {selectedTag && (
+              <button
+                onClick={() => setSelectedTag(undefined)}
+                className="flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium bg-primary text-primary-foreground"
+              >
+                #{selectedTag}
+                <X className="w-3 h-3" />
+              </button>
+            )}
+            {popularTags
+              .filter((t) => t.tag.name !== selectedTag)
+              .map((t) => (
+                <button
+                  key={t.tag.id}
+                  onClick={() => setSelectedTag(t.tag.name)}
+                  className="px-2.5 py-1 rounded-full text-xs font-medium bg-muted/50 text-muted-foreground border border-border/40 hover:border-primary/40 hover:text-foreground transition-all"
+                >
+                  #{t.tag.name}
+                  <span className="ml-1 text-[10px] opacity-60">{t.count}</span>
+                </button>
+              ))}
+          </div>
+        )}
       </div>
 
       {/* Content Grid */}
@@ -86,7 +176,7 @@ export default function Discover() {
           <div className="text-5xl mb-4">🔍</div>
           <h3 className="text-xl font-semibold mb-2">No content found</h3>
           <p className="text-muted-foreground">
-            {keyword ? `No results for "${keyword}"` : "Be the first to share something!"}
+            {keyword ? `No results for "${keyword}"` : selectedTag ? `No content tagged #${selectedTag}` : "Be the first to share something!"}
           </p>
         </div>
       ) : (

--- a/client/src/pages/Feed.tsx
+++ b/client/src/pages/Feed.tsx
@@ -1,0 +1,49 @@
+import { trpc } from "@/lib/trpc";
+import { Link } from "wouter";
+import { Button } from "@/components/ui/button";
+import { Loader2, Compass, Rss } from "lucide-react";
+import ContentCard from "@/components/ContentCard";
+
+export default function Feed() {
+  const { data, isLoading } = trpc.content.feed.useQuery({ limit: 30, offset: 0 });
+
+  return (
+    <div className="container py-12">
+      {/* Header */}
+      <div className="mb-10">
+        <h1 className="text-3xl font-bold mb-2 flex items-center gap-3">
+          <Rss className="w-7 h-7 text-primary" />
+          Feed
+        </h1>
+        <p className="text-muted-foreground">Latest content from people you follow</p>
+      </div>
+
+      {/* Content Grid */}
+      {isLoading ? (
+        <div className="flex items-center justify-center py-24">
+          <Loader2 className="w-8 h-8 animate-spin text-primary" />
+        </div>
+      ) : !data || data.length === 0 ? (
+        <div className="text-center py-24">
+          <div className="text-5xl mb-4">📡</div>
+          <h3 className="text-xl font-semibold mb-2">Your feed is empty</h3>
+          <p className="text-muted-foreground mb-6">
+            Follow creators on Discover to see their latest works here
+          </p>
+          <Link href="/discover">
+            <Button className="gap-2 bg-primary hover:bg-primary/90 text-primary-foreground">
+              <Compass className="w-4 h-4" />
+              Explore Discover
+            </Button>
+          </Link>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5">
+          {data.map((item) => (
+            <ContentCard key={item.content.id} content={item.content} author={item.author} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/pages/Profile.tsx
+++ b/client/src/pages/Profile.tsx
@@ -1,4 +1,5 @@
 import { useAuth } from "@/_core/hooks/useAuth";
+import { getLoginUrl } from "@/const";
 import { trpc } from "@/lib/trpc";
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
@@ -6,7 +7,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Link, useParams } from "wouter";
 import { useState } from "react";
 import { toast } from "sonner";
-import { Loader2, Edit2, Check, X } from "lucide-react";
+import { Loader2, Edit2, Check, X, UserPlus, UserCheck } from "lucide-react";
 import ContentCard from "@/components/ContentCard";
 
 export default function Profile() {
@@ -32,6 +33,13 @@ export default function Profile() {
     onError: () => toast.error("Failed to update bio"),
   });
 
+  const followMutation = trpc.user.toggleFollow.useMutation({
+    onSuccess: (res) => {
+      utils.user.getProfile.invalidate({ userId });
+      toast.success(res.following ? "Followed!" : "Unfollowed");
+    },
+  });
+
   if (isLoading) {
     return (
       <div className="flex items-center justify-center min-h-96">
@@ -49,7 +57,7 @@ export default function Profile() {
     );
   }
 
-  const { user, contents } = data;
+  const { user, contents, followCounts, following } = data;
   const isOwnProfile = currentUser?.id === userId;
 
   const startEditBio = () => {
@@ -78,6 +86,24 @@ export default function Profile() {
                 onClick={startEditBio}
               >
                 <Edit2 className="w-3.5 h-3.5" />
+              </Button>
+            )}
+            {!isOwnProfile && (
+              <Button
+                variant={following ? "outline" : "default"}
+                size="sm"
+                className={`gap-1.5 ${following ? "border-primary/40 text-primary" : "bg-primary hover:bg-primary/90 text-primary-foreground"}`}
+                onClick={() => {
+                  if (!isAuthenticated) { window.location.href = getLoginUrl(); return; }
+                  followMutation.mutate({ userId });
+                }}
+                disabled={followMutation.isPending}
+              >
+                {following ? (
+                  <><UserCheck className="w-3.5 h-3.5" />Following</>
+                ) : (
+                  <><UserPlus className="w-3.5 h-3.5" />Follow</>
+                )}
               </Button>
             )}
           </div>
@@ -121,6 +147,12 @@ export default function Profile() {
           <div className="flex items-center gap-6 mt-4 text-sm text-muted-foreground">
             <span>
               <strong className="text-foreground">{contents.length}</strong> public works
+            </span>
+            <span>
+              <strong className="text-foreground">{followCounts.followers}</strong> followers
+            </span>
+            <span>
+              <strong className="text-foreground">{followCounts.following}</strong> following
             </span>
             <span>Joined {new Date(user.createdAt).toLocaleDateString("ja-JP", { year: "numeric", month: "long" })}</span>
           </div>

--- a/drizzle/0002_community_v1_1.sql
+++ b/drizzle/0002_community_v1_1.sql
@@ -1,0 +1,12 @@
+-- v1.1: Community features (remix, follows)
+ALTER TABLE `contents` ADD `parentContentId` int;
+--> statement-breakpoint
+ALTER TABLE `contents` ADD `remixCount` int NOT NULL DEFAULT 0;
+--> statement-breakpoint
+CREATE TABLE `follows` (
+	`id` int AUTO_INCREMENT NOT NULL,
+	`userId` int NOT NULL,
+	`followedUserId` int NOT NULL,
+	`createdAt` timestamp NOT NULL DEFAULT (now()),
+	CONSTRAINT `follows_id` PRIMARY KEY(`id`)
+);

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -46,6 +46,9 @@ export const contents = mysqlTable("contents", {
   status: mysqlEnum("status", ["pending", "generating", "completed", "failed"])
     .default("pending")
     .notNull(),
+  // Remix
+  parentContentId: int("parentContentId"),
+  remixCount: int("remixCount").default(0).notNull(),
   // Stats
   viewCount: int("viewCount").default(0).notNull(),
   likeCount: int("likeCount").default(0).notNull(),
@@ -104,3 +107,13 @@ export const bookmarks = mysqlTable("bookmarks", {
 });
 
 export type Bookmark = typeof bookmarks.$inferSelect;
+
+// Follows
+export const follows = mysqlTable("follows", {
+  id: int("id").autoincrement().primaryKey(),
+  userId: int("userId").notNull(),
+  followedUserId: int("followedUserId").notNull(),
+  createdAt: timestamp("createdAt").defaultNow().notNull(),
+});
+
+export type Follow = typeof follows.$inferSelect;

--- a/server/content.test.ts
+++ b/server/content.test.ts
@@ -226,3 +226,44 @@ describe("content.discover - input validation", () => {
     ).rejects.toThrow();
   });
 });
+
+// ─── v1.2 Feature Tests ──────────────────────────────────────────────────────
+
+describe("content.uploadFile - auth & validation", () => {
+  it("uploadFile requires authentication", async () => {
+    const caller = appRouter.createCaller(createPublicContext());
+    await expect(
+      caller.content.uploadFile({ fileBase64: "dGVzdA==", fileName: "test.png", mimeType: "image/png" })
+    ).rejects.toThrow();
+  });
+
+  it("uploadFile rejects invalid mimeType", async () => {
+    const caller = appRouter.createCaller(createAuthContext());
+    await expect(
+      caller.content.uploadFile({ fileBase64: "dGVzdA==", fileName: "test.txt", mimeType: "text/plain" as any })
+    ).rejects.toThrow();
+  });
+});
+
+describe("content.extractText - auth & validation", () => {
+  it("extractText requires authentication", async () => {
+    const caller = appRouter.createCaller(createPublicContext());
+    await expect(
+      caller.content.extractText({ source: "url", url: "https://example.com" })
+    ).rejects.toThrow();
+  });
+
+  it("extractText rejects invalid source", async () => {
+    const caller = appRouter.createCaller(createAuthContext());
+    await expect(
+      caller.content.extractText({ source: "invalid" as any, url: "https://example.com" })
+    ).rejects.toThrow();
+  });
+
+  it("extractText rejects empty url", async () => {
+    const caller = appRouter.createCaller(createAuthContext());
+    await expect(
+      caller.content.extractText({ source: "image", url: "" })
+    ).rejects.toThrow();
+  });
+});

--- a/server/content.test.ts
+++ b/server/content.test.ts
@@ -165,3 +165,64 @@ describe("user router - input validation", () => {
     await expect(caller.user.updateBio({ bio: "hello" })).rejects.toThrow();
   });
 });
+
+// ─── v1.1 Feature Tests ──────────────────────────────────────────────────────
+
+describe("content.remix - auth protection", () => {
+  it("remix requires authentication", async () => {
+    const caller = appRouter.createCaller(createPublicContext());
+    await expect(
+      caller.content.remix({ contentId: 1, targetFormat: "flashcard", tags: [], isPublic: false })
+    ).rejects.toThrow();
+  });
+
+  it("remix rejects invalid targetFormat", async () => {
+    const caller = appRouter.createCaller(createAuthContext());
+    await expect(
+      caller.content.remix({ contentId: 1, targetFormat: "invalid" as any, tags: [], isPublic: false })
+    ).rejects.toThrow();
+  });
+
+  it("remix rejects too many tags", async () => {
+    const caller = appRouter.createCaller(createAuthContext());
+    await expect(
+      caller.content.remix({ contentId: 1, targetFormat: "novel", tags: ["a", "b", "c", "d", "e", "f"], isPublic: false })
+    ).rejects.toThrow();
+  });
+});
+
+describe("content.feed - auth protection", () => {
+  it("feed requires authentication", async () => {
+    const caller = appRouter.createCaller(createPublicContext());
+    await expect(caller.content.feed({ limit: 10, offset: 0 })).rejects.toThrow();
+  });
+});
+
+describe("user.toggleFollow - auth protection", () => {
+  it("toggleFollow requires authentication", async () => {
+    const caller = appRouter.createCaller(createPublicContext());
+    await expect(caller.user.toggleFollow({ userId: 2 })).rejects.toThrow();
+  });
+
+  it("toggleFollow rejects self-follow", async () => {
+    const caller = appRouter.createCaller(createAuthContext({ id: 1 }));
+    await expect(caller.user.toggleFollow({ userId: 1 })).rejects.toThrow();
+  });
+});
+
+describe("content.discover - input validation", () => {
+  it("discover accepts sortBy parameter", async () => {
+    const caller = appRouter.createCaller(createPublicContext());
+    // Should not throw with valid sortBy
+    await expect(
+      caller.content.discover({ sortBy: "invalid_sort" as any, limit: 10, offset: 0, period: "all" })
+    ).rejects.toThrow();
+  });
+
+  it("discover accepts period parameter", async () => {
+    const caller = appRouter.createCaller(createPublicContext());
+    await expect(
+      caller.content.discover({ sortBy: "trending", period: "invalid_period" as any, limit: 10, offset: 0 })
+    ).rejects.toThrow();
+  });
+});

--- a/server/db.ts
+++ b/server/db.ts
@@ -1,9 +1,10 @@
-import { and, desc, eq, like, or, sql } from "drizzle-orm";
+import { and, desc, eq, gte, like, or, sql, inArray } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/mysql2";
 import {
   Bookmark,
   Comment,
   Content,
+  Follow,
   InsertContent,
   InsertUser,
   Like,
@@ -12,6 +13,7 @@ import {
   comments,
   contentTags,
   contents,
+  follows,
   likes,
   tags,
   users,
@@ -131,6 +133,8 @@ export async function listPublicContents(opts: {
   format?: string;
   tagName?: string;
   keyword?: string;
+  sortBy?: "recent" | "trending" | "top";
+  period?: "week" | "month" | "all";
   limit?: number;
   offset?: number;
 }) {
@@ -139,7 +143,41 @@ export async function listPublicContents(opts: {
   const limit = opts.limit ?? 20;
   const offset = opts.offset ?? 0;
 
-  let query = db
+  // If filtering by tag, find matching content IDs first
+  let tagContentIds: number[] | undefined;
+  if (opts.tagName) {
+    const tagRows = await db
+      .select({ contentId: contentTags.contentId })
+      .from(contentTags)
+      .innerJoin(tags, eq(contentTags.tagId, tags.id))
+      .where(eq(tags.name, opts.tagName));
+    tagContentIds = tagRows.map((r) => r.contentId);
+    if (tagContentIds.length === 0) return [];
+  }
+
+  // Period filter
+  let periodFilter;
+  if (opts.period && opts.period !== "all") {
+    const now = new Date();
+    const daysAgo = opts.period === "week" ? 7 : 30;
+    const since = new Date(now.getTime() - daysAgo * 24 * 60 * 60 * 1000);
+    periodFilter = gte(contents.createdAt, since);
+  }
+
+  // Sort order
+  let orderClause;
+  switch (opts.sortBy) {
+    case "trending":
+      orderClause = desc(sql`(${contents.likeCount} * 3 + ${contents.viewCount} + ${contents.commentCount} * 2)`);
+      break;
+    case "top":
+      orderClause = desc(contents.likeCount);
+      break;
+    default:
+      orderClause = desc(contents.createdAt);
+  }
+
+  return db
     .select({
       content: contents,
       author: { id: users.id, name: users.name },
@@ -156,14 +194,31 @@ export async function listPublicContents(opts: {
               like(contents.title, `%${opts.keyword}%`),
               like(contents.description, `%${opts.keyword}%`)
             )
-          : undefined
+          : undefined,
+        tagContentIds ? inArray(contents.id, tagContentIds) : undefined,
+        periodFilter
       )
     )
-    .orderBy(desc(contents.createdAt))
+    .orderBy(orderClause)
     .limit(limit)
     .offset(offset);
+}
 
-  return query;
+// List popular tags (by content count)
+export async function listPopularTags(limit: number = 20) {
+  const db = await getDb();
+  if (!db) return [];
+  return db
+    .select({
+      tag: tags,
+      count: sql<number>`count(${contentTags.contentId})`.as("content_count"),
+    })
+    .from(tags)
+    .innerJoin(contentTags, eq(tags.id, contentTags.tagId))
+    .innerJoin(contents, and(eq(contentTags.contentId, contents.id), eq(contents.isPublic, true), eq(contents.status, "completed")))
+    .groupBy(tags.id)
+    .orderBy(desc(sql`content_count`))
+    .limit(limit);
 }
 
 // List user's own contents
@@ -324,4 +379,109 @@ export async function getComments(contentId: number) {
     .innerJoin(users, eq(comments.userId, users.id))
     .where(eq(comments.contentId, contentId))
     .orderBy(desc(comments.createdAt));
+}
+
+// ─── Remix ───────────────────────────────────────────────────────────────────
+
+export async function incrementRemixCount(contentId: number) {
+  const db = await getDb();
+  if (!db) return;
+  await db.update(contents).set({ remixCount: sql`${contents.remixCount} + 1` }).where(eq(contents.id, contentId));
+}
+
+export async function getRemixes(contentId: number) {
+  const db = await getDb();
+  if (!db) return [];
+  return db
+    .select({
+      content: contents,
+      author: { id: users.id, name: users.name },
+    })
+    .from(contents)
+    .innerJoin(users, eq(contents.userId, users.id))
+    .where(and(eq(contents.parentContentId, contentId), eq(contents.isPublic, true), eq(contents.status, "completed")))
+    .orderBy(desc(contents.createdAt));
+}
+
+// ─── Follows ─────────────────────────────────────────────────────────────────
+
+export async function toggleFollow(userId: number, followedUserId: number): Promise<boolean> {
+  const db = await getDb();
+  if (!db) throw new Error("DB not available");
+  if (userId === followedUserId) throw new Error("Cannot follow yourself");
+
+  const existing = await db
+    .select()
+    .from(follows)
+    .where(and(eq(follows.userId, userId), eq(follows.followedUserId, followedUserId)))
+    .limit(1);
+
+  if (existing[0]) {
+    await db.delete(follows).where(and(eq(follows.userId, userId), eq(follows.followedUserId, followedUserId)));
+    return false;
+  } else {
+    await db.insert(follows).values({ userId, followedUserId });
+    return true;
+  }
+}
+
+export async function isFollowing(userId: number, followedUserId: number): Promise<boolean> {
+  const db = await getDb();
+  if (!db) return false;
+  const result = await db
+    .select()
+    .from(follows)
+    .where(and(eq(follows.userId, userId), eq(follows.followedUserId, followedUserId)))
+    .limit(1);
+  return !!result[0];
+}
+
+export async function getFollowCounts(userId: number): Promise<{ followers: number; following: number }> {
+  const db = await getDb();
+  if (!db) return { followers: 0, following: 0 };
+  const [followerRows] = await db
+    .select({ count: sql<number>`count(*)` })
+    .from(follows)
+    .where(eq(follows.followedUserId, userId));
+  const [followingRows] = await db
+    .select({ count: sql<number>`count(*)` })
+    .from(follows)
+    .where(eq(follows.userId, userId));
+  return {
+    followers: Number(followerRows?.count ?? 0),
+    following: Number(followingRows?.count ?? 0),
+  };
+}
+
+export async function listFollowingFeed(userId: number, opts?: { limit?: number; offset?: number }) {
+  const db = await getDb();
+  if (!db) return [];
+  const limit = opts?.limit ?? 20;
+  const offset = opts?.offset ?? 0;
+
+  // Get IDs of followed users
+  const followedRows = await db
+    .select({ followedUserId: follows.followedUserId })
+    .from(follows)
+    .where(eq(follows.userId, userId));
+  const followedIds = followedRows.map((r) => r.followedUserId);
+  if (followedIds.length === 0) return [];
+
+  return db
+    .select({
+      content: contents,
+      author: { id: users.id, name: users.name },
+    })
+    .from(contents)
+    .innerJoin(users, eq(contents.userId, users.id))
+    .where(
+      and(
+        inArray(contents.userId, followedIds),
+        eq(contents.isPublic, true),
+        eq(contents.status, "completed")
+      )
+    )
+    .orderBy(desc(contents.createdAt))
+    .limit(limit)
+    .offset(offset);
 }

--- a/server/routers.ts
+++ b/server/routers.ts
@@ -15,14 +15,21 @@ import {
   getContentById,
   getContentTags,
   getComments,
+  getFollowCounts,
+  getRemixes,
   getUserById,
+  incrementRemixCount,
   incrementViewCount,
   isBookmarked,
+  isFollowing,
   isLiked,
+  listFollowingFeed,
+  listPopularTags,
   listPublicContents,
   listUserContents,
   setContentTags,
   toggleBookmark,
+  toggleFollow,
   toggleLike,
   updateContent,
   updateUserBio,
@@ -357,6 +364,35 @@ async function generatePoem(sourceText: string, title: string): Promise<string> 
   return (res.choices[0]?.message?.content as string) ?? "{}";
 }
 
+// ─── Remix text extraction ───────────────────────────────────────────────────
+
+function extractTextFromOutputData(outputData: string, format: string): string {
+  try {
+    const data = JSON.parse(outputData);
+    switch (format) {
+      case "novel":
+        return (data.chapters ?? []).map((ch: any) => `${ch.title}\n${ch.body}`).join("\n\n");
+      case "manga":
+        return (data.panels ?? [])
+          .map((p: any) => {
+            const dialogues = (p.dialogue ?? []).map((d: any) => `${d.character}: ${d.text}`).join("\n");
+            return `${p.description}\n${dialogues}`;
+          })
+          .join("\n\n");
+      case "flashcard":
+        return (data.cards ?? []).map((c: any) => `Q: ${c.question}\nA: ${c.answer}`).join("\n\n");
+      case "video_script":
+        return (data.scenes ?? []).map((s: any) => s.narration).join("\n\n");
+      case "poem":
+        return (data.stanzas ?? []).map((s: any) => (s.lines ?? []).join("\n")).join("\n\n");
+      default:
+        return outputData;
+    }
+  } catch {
+    return outputData;
+  }
+}
+
 // ─── Routers ──────────────────────────────────────────────────────────────────
 
 export const appRouter = router({
@@ -499,12 +535,21 @@ export const appRouter = router({
         z.object({
           format: z.enum(OUTPUT_FORMATS).optional(),
           keyword: z.string().optional(),
+          tagName: z.string().optional(),
+          sortBy: z.enum(["recent", "trending", "top"]).default("recent"),
+          period: z.enum(["week", "month", "all"]).default("all"),
           limit: z.number().min(1).max(50).default(20),
           offset: z.number().default(0),
         })
       )
       .query(async ({ input }) => {
         return listPublicContents(input);
+      }),
+
+    popularTags: publicProcedure
+      .input(z.object({ limit: z.number().min(1).max(50).default(20) }).optional())
+      .query(async ({ input }) => {
+        return listPopularTags(input?.limit ?? 20);
       }),
 
     // ─── My library ───────────────────────────────────────────────────────
@@ -555,18 +600,110 @@ export const appRouter = router({
     myBookmarks: protectedProcedure.query(async ({ ctx }) => {
       return getBookmarkedContents(ctx.user.id);
     }),
+
+    // ─── Remix ──────────────────────────────────────────────────────────
+    remix: protectedProcedure
+      .input(
+        z.object({
+          contentId: z.number(),
+          targetFormat: z.enum(OUTPUT_FORMATS),
+          title: z.string().min(1).max(255).optional(),
+          tags: z.array(z.string()).max(5).default([]),
+          isPublic: z.boolean().default(false),
+        })
+      )
+      .mutation(async ({ ctx, input }) => {
+        const original = await getContentById(input.contentId);
+        if (!original) throw new TRPCError({ code: "NOT_FOUND" });
+        if (!original.isPublic && original.userId !== ctx.user.id) {
+          throw new TRPCError({ code: "FORBIDDEN" });
+        }
+        if (input.targetFormat === original.outputFormat) {
+          throw new TRPCError({ code: "BAD_REQUEST", message: "Target format must differ from original" });
+        }
+
+        const sourceText = extractTextFromOutputData(original.outputData, original.outputFormat);
+        const title = input.title ?? `${original.title} (${input.targetFormat.replace("_", " ")})`;
+
+        const contentId = await createContent({
+          userId: ctx.user.id,
+          title,
+          description: `Remixed from "${original.title}"`,
+          sourceText,
+          outputFormat: input.targetFormat,
+          outputData: "{}",
+          isPublic: input.isPublic,
+          status: "generating",
+          parentContentId: original.id,
+        });
+
+        try {
+          let outputData: string;
+          switch (input.targetFormat) {
+            case "novel":
+              outputData = await generateNovel(sourceText, title);
+              break;
+            case "manga":
+              const mangaResult = await generateManga(sourceText, title);
+              outputData = mangaResult.data;
+              break;
+            case "flashcard":
+              outputData = await generateFlashcards(sourceText, title);
+              break;
+            case "video_script":
+              outputData = await generateVideoScript(sourceText, title);
+              break;
+            case "poem":
+              outputData = await generatePoem(sourceText, title);
+              break;
+            default:
+              throw new Error("Unsupported format");
+          }
+
+          let coverImageUrl: string | undefined;
+          try {
+            const coverPrompt = `${input.targetFormat} cover art for "${title}", artistic, colorful, educational, modern illustration style`;
+            const { url } = await generateImage({ prompt: coverPrompt });
+            coverImageUrl = url;
+          } catch {}
+
+          await updateContent(contentId, { outputData, coverImageUrl, status: "completed" });
+          if (input.tags.length > 0) await setContentTags(contentId, input.tags);
+          await incrementRemixCount(original.id);
+
+          return { contentId, status: "completed" };
+        } catch (err) {
+          await updateContent(contentId, { status: "failed" });
+          throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Remix generation failed" });
+        }
+      }),
+
+    getRemixes: publicProcedure
+      .input(z.object({ contentId: z.number() }))
+      .query(async ({ input }) => {
+        return getRemixes(input.contentId);
+      }),
+
+    // ─── Feed ───────────────────────────────────────────────────────────
+    feed: protectedProcedure
+      .input(z.object({ limit: z.number().min(1).max(50).default(20), offset: z.number().default(0) }))
+      .query(async ({ ctx, input }) => {
+        return listFollowingFeed(ctx.user.id, input);
+      }),
   }),
 
   // ─── User profile ──────────────────────────────────────────────────────────
   user: router({
     getProfile: publicProcedure
       .input(z.object({ userId: z.number() }))
-      .query(async ({ input }) => {
+      .query(async ({ ctx, input }) => {
         const user = await getUserById(input.userId);
         if (!user) throw new TRPCError({ code: "NOT_FOUND" });
         const userContents = await listUserContents(input.userId, { limit: 20 });
         const publicContents = userContents.filter((c) => c.isPublic && c.status === "completed");
-        return { user, contents: publicContents };
+        const followCounts = await getFollowCounts(input.userId);
+        const following = ctx.user ? await isFollowing(ctx.user.id, input.userId) : false;
+        return { user, contents: publicContents, followCounts, following };
       }),
 
     updateBio: protectedProcedure
@@ -574,6 +711,16 @@ export const appRouter = router({
       .mutation(async ({ ctx, input }) => {
         await updateUserBio(ctx.user.id, input.bio);
         return { success: true };
+      }),
+
+    toggleFollow: protectedProcedure
+      .input(z.object({ userId: z.number() }))
+      .mutation(async ({ ctx, input }) => {
+        if (ctx.user.id === input.userId) {
+          throw new TRPCError({ code: "BAD_REQUEST", message: "Cannot follow yourself" });
+        }
+        const following = await toggleFollow(ctx.user.id, input.userId);
+        return { following };
       }),
   }),
 });

--- a/server/routers.ts
+++ b/server/routers.ts
@@ -393,6 +393,72 @@ function extractTextFromOutputData(outputData: string, format: string): string {
   }
 }
 
+// ─── Text extraction helpers (v1.2) ─────────────────────────────────────────
+
+async function extractTextFromImage(imageUrl: string): Promise<string> {
+  const res = await invokeLLM({
+    messages: [
+      {
+        role: "system" as const,
+        content: "あなたはOCRスペシャリストです。画像からテキストを正確に読み取り、原文のまま書き起こしてください。表・リスト・数式がある場合はその構造を保持してください。画像にテキストがない場合は、画像の内容を詳細に説明してください。結果はプレーンテキストのみで返してください。",
+      },
+      {
+        role: "user" as const,
+        content: [
+          { type: "text" as const, text: "この画像からテキストを抽出してください。" },
+          { type: "image_url" as const, image_url: { url: imageUrl, detail: "high" as const } },
+        ],
+      },
+    ],
+  });
+  return (res.choices[0]?.message?.content as string) ?? "";
+}
+
+async function extractTextFromPdf(pdfUrl: string): Promise<string> {
+  const res = await invokeLLM({
+    messages: [
+      {
+        role: "system" as const,
+        content: "あなたはドキュメント解析スペシャリストです。PDFの内容を正確にテキストとして書き起こしてください。見出し・段落・リスト・表の構造を可能な限り保持してください。結果はプレーンテキストのみで返してください。",
+      },
+      {
+        role: "user" as const,
+        content: [
+          { type: "text" as const, text: "このPDFの内容をテキストとして抽出してください。" },
+          { type: "file_url" as const, file_url: { url: pdfUrl, mime_type: "application/pdf" as const } },
+        ],
+      },
+    ],
+  });
+  return (res.choices[0]?.message?.content as string) ?? "";
+}
+
+async function extractTextFromUrl(url: string): Promise<string> {
+  // Fetch the URL content server-side
+  const response = await fetch(url, {
+    headers: { "User-Agent": "Manashift/1.2 (content-extractor)" },
+  });
+  if (!response.ok) throw new Error(`Failed to fetch URL: ${response.status}`);
+
+  const html = await response.text();
+
+  // Use LLM to extract meaningful text from HTML
+  const truncatedHtml = html.slice(0, 30000); // Limit to avoid token overflow
+  const res = await invokeLLM({
+    messages: [
+      {
+        role: "system" as const,
+        content: "あなたはWebコンテンツ抽出スペシャリストです。与えられたHTMLから、メインコンテンツのテキストを抽出してください。ナビゲーション・フッター・広告・スクリプトは除外してください。見出し・段落・リストの構造を保持してください。結果はプレーンテキストのみで返してください。",
+      },
+      {
+        role: "user" as const,
+        content: `以下のHTMLからメインコンテンツを抽出してください:\n\n${truncatedHtml}`,
+      },
+    ],
+  });
+  return (res.choices[0]?.message?.content as string) ?? "";
+}
+
 // ─── Routers ──────────────────────────────────────────────────────────────────
 
 export const appRouter = router({
@@ -480,6 +546,53 @@ export const appRouter = router({
         } catch (err) {
           await updateContent(contentId, { status: "failed" });
           throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Generation failed" });
+        }
+      }),
+
+    // ─── v1.2 Input extraction ─────────────────────────────────────────────
+    uploadFile: protectedProcedure
+      .input(
+        z.object({
+          fileBase64: z.string().min(1),
+          fileName: z.string().min(1),
+          mimeType: z.enum(["image/png", "image/jpeg", "image/webp", "application/pdf"]),
+        })
+      )
+      .mutation(async ({ input }) => {
+        const buffer = Buffer.from(input.fileBase64, "base64");
+        const ext = input.mimeType === "application/pdf" ? "pdf" : input.mimeType.split("/")[1];
+        const key = `uploads/${Date.now()}_${Math.random().toString(36).slice(2)}.${ext}`;
+        const { url } = await storagePut(key, buffer, input.mimeType);
+        return { url, mimeType: input.mimeType };
+      }),
+
+    extractText: protectedProcedure
+      .input(
+        z.object({
+          source: z.enum(["image", "pdf", "url"]),
+          url: z.string().min(1),
+        })
+      )
+      .mutation(async ({ input }) => {
+        try {
+          let text: string;
+          switch (input.source) {
+            case "image":
+              text = await extractTextFromImage(input.url);
+              break;
+            case "pdf":
+              text = await extractTextFromPdf(input.url);
+              break;
+            case "url":
+              text = await extractTextFromUrl(input.url);
+              break;
+          }
+          return { text };
+        } catch (err) {
+          throw new TRPCError({
+            code: "INTERNAL_SERVER_ERROR",
+            message: `Text extraction failed: ${err instanceof Error ? err.message : "Unknown error"}`,
+          });
         }
       }),
 


### PR DESCRIPTION
## Summary

v1.1（コミュニティ深化）と v1.2（入力拡張）の全7機能を実装。

### v1.1 — コミュニティ深化
- **タグ検索・絞り込み**: Discoverページで人気タグをバッジ表示、クリックでフィルタリング
- **ランキング（トレンド）**: 新着 / Trending / Top のソート切替、期間フィルタ（週間/月間/全期間）
- **リミックス機能**: 既存コンテンツを別フォーマットに変換。スキーマに `parentContentId` / `remixCount` 追加、ContentDetailにリミックスボタン
- **フォロー・フィード**: follows テーブル追加、プロフィールにフォローボタン・カウント表示、パーソナライズドフィードページ

### v1.2 — 入力拡張
- **画像入力 (OCR)**: Gemini Vision で画像からテキスト抽出
- **PDF入力**: Gemini file_url でPDFテキスト抽出
- **URL入力**: HTMLフェッチ → LLMでメインコンテンツ抽出

### 変更内容
- 12ファイル変更、+1,080行 / -30行
- スキーマ変更: `parentContentId`, `remixCount` カラム追加、`follows` テーブル追加
- マイグレーション: `drizzle/0002_community_v1_1.sql`
- 新規ページ: `Feed.tsx`
- テスト: 13件 → 26件（全通過）

## Test plan
- [x] `pnpm test` — 26/26テスト通過
- [x] `pnpm check` — TypeScript型チェック通過
- [ ] `pnpm dev` でローカル動作確認
- [ ] `pnpm drizzle-kit generate` でマイグレーション整合性確認

🤖 Generated with [Claude Code](https://claude.ai/code)